### PR TITLE
CMake Fixes, GCC v13 Compatibility, and Newer libOTe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,3 +24,14 @@ add_subdirectory(frontend)
 
 # setup the install
 include(cmake/install.cmake)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/secureJoinConfig.cmake"
+  INSTALL_DESTINATION lib/cmake/secureJoin
+)
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/secureJoinConfig.cmake"
+  DESTINATION lib/cmake/secureJoin
+)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,16 +1,1 @@
 @PACKAGE_INIT@
-
-
-message(FATAL_ERROR "fix me")
-
-include("${CMAKE_CURRENT_LIST_DIR}/volePSITargets.cmake")
-
-include("${CMAKE_CURRENT_LIST_DIR}/findDependancies.cmake")
-
-
-get_target_property(SECUREJOIN_INCLUDE_DIRS visa::volePSI INTERFACE_INCLUDE_DIRECTORIES)
-
-get_target_property(SECUREJOIN_LIBRARIES visa::volePSI LOCATION)
-
-message("SECUREJOIN_INCLUDE_DIRS=${SECUREJOIN_INCLUDE_DIRS}")
-message("SECUREJOIN_LIBRARIES=${SECUREJOIN_LIBRARIES}")

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -4,7 +4,6 @@
 #            Install                        #
 #############################################
 
-#############################################
 configure_file("${CMAKE_CURRENT_LIST_DIR}/findDependancies.cmake" "findDependancies.cmake" COPYONLY)
 configure_file("${CMAKE_CURRENT_LIST_DIR}/preamble.cmake" "preamble.cmake" COPYONLY)
 
@@ -63,4 +62,11 @@ install(EXPORT secureJoinTargets
  export(EXPORT secureJoinTargets
        FILE "${CMAKE_CURRENT_BINARY_DIR}/secureJoinTargets.cmake"
        NAMESPACE visa::
+)
+
+install(DIRECTORY secure-join DESTINATION include/secureJoin)
+
+install(FILES 
+    out/build/linux/secure-join/config.h   # Install the generated config.h
+    DESTINATION include/secureJoin/secure-join
 )

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -4,66 +4,63 @@
 #            Install                        #
 #############################################
 
-
-# configure_file("${CMAKE_CURRENT_LIST_DIR}/findDependancies.cmake" "findDependancies.cmake" COPYONLY)
-# configure_file("${CMAKE_CURRENT_LIST_DIR}/preamble.cmake" "preamble.cmake" COPYONLY)
+#############################################
+configure_file("${CMAKE_CURRENT_LIST_DIR}/findDependancies.cmake" "findDependancies.cmake" COPYONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/preamble.cmake" "preamble.cmake" COPYONLY)
 
 # # make cache variables for install destinations
-# include(GNUInstallDirs)
-# include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 
-# # generate the config file that is includes the exports
-# configure_package_config_file(
-#   "${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in"
-#   "${CMAKE_CURRENT_BINARY_DIR}/SECUREJOINConfig.cmake"
-#   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SECUREJOIN
-#   NO_SET_AND_CHECK_MACRO
-#   NO_CHECK_REQUIRED_COMPONENTS_MACRO
-# )
+# generate the config file that is includes the exports
+configure_package_config_file(
+  "${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/secureJoinConfig.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/secureJoin
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
 
-# if(NOT DEFINED SECUREJOIN_VERSION_MAJOR)
-#     message("\n\n\n\n warning, SECUREJOIN_VERSION_MAJOR not defined ${SECUREJOIN_VERSION_MAJOR}")
-# endif()
+if(NOT DEFINED SECUREJOIN_VERSION_MAJOR)
+    message("\n\n\n\n warning, SECUREJOIN_VERSION_MAJOR not defined ${SECUREJOIN_VERSION_MAJOR}")
+endif()
+set_property(TARGET secureJoin PROPERTY VERSION ${SECUREJOIN_VERSION})
+# generate the version file for the config file
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/SECUREJOINConfigVersion.cmake"
+  VERSION "${SECUREJOIN_VERSION_MAJOR}.${SECUREJOIN_VERSION_MINOR}.${SECUREJOIN_VERSION_PATCH}"
+  COMPATIBILITY AnyNewerVersion
+)
 
-# set_property(TARGET SECUREJOIN PROPERTY VERSION ${SECUREJOIN_VERSION})
+# install the configuration file
+install(FILES
+          "${CMAKE_CURRENT_BINARY_DIR}/secureJoinConfig.cmake"
+          "${CMAKE_CURRENT_BINARY_DIR}/findDependancies.cmake"
+          "${CMAKE_CURRENT_BINARY_DIR}/preamble.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/secureJoin
+)
 
-# # generate the version file for the config file
-# write_basic_package_version_file(
-#   "${CMAKE_CURRENT_BINARY_DIR}/SECUREJOINConfigVersion.cmake"
-#   VERSION "${SECUREJOIN_VERSION_MAJOR}.${SECUREJOIN_VERSION_MINOR}.${SECUREJOIN_VERSION_PATCH}"
-#   COMPATIBILITY AnyNewerVersion
-# )
+# install library
+install(
+    TARGETS secureJoin
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    EXPORT secureJoinTargets)
 
-# # install the configuration file
-# install(FILES
-#           "${CMAKE_CURRENT_BINARY_DIR}/SECUREJOINConfig.cmake"
-#           "${CMAKE_CURRENT_BINARY_DIR}/SECUREJOINConfigVersion.cmake"
-#           "${CMAKE_CURRENT_BINARY_DIR}/findDependancies.cmake"
-#           "${CMAKE_CURRENT_BINARY_DIR}/preamble.cmake"
-#         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SECUREJOIN
-# )
-
-# # install library
-# install(
-#     TARGETS SECUREJOIN
-#     DESTINATION ${CMAKE_INSTALL_LIBDIR}
-#     EXPORT SECUREJOINTargets)
-
-# # install headers
-# install(
-#     DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../SECUREJOIN"
-#     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/"
-#     FILES_MATCHING PATTERN "*.h")
+# install headers
+install(
+    DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../secureJoin"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/"
+    FILES_MATCHING PATTERN "*.h")
 
 
-# # install config
-# install(EXPORT SECUREJOINTargets
-#   FILE SECUREJOINTargets.cmake
-#   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SECUREJOIN
-#        NAMESPACE visa::
-# )
-#  export(EXPORT SECUREJOINTargets
-#        FILE "${CMAKE_CURRENT_BINARY_DIR}/SECUREJOINTargets.cmake"
-#        NAMESPACE visa::
-# )
+# install config
+install(EXPORT secureJoinTargets
+  FILE secureJoinTargets.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/secureJoin
+       NAMESPACE visa::
+)
+ export(EXPORT secureJoinTargets
+       FILE "${CMAKE_CURRENT_BINARY_DIR}/secureJoinTargets.cmake"
+       NAMESPACE visa::
+)

--- a/cmake/secureJoinConfig.cmake
+++ b/cmake/secureJoinConfig.cmake
@@ -1,10 +1,3 @@
 # these are just pass through config file for the ones that are placed in the build directory.
 
-message(FATAL_ERROR "fix me")
 include("${CMAKE_CURRENT_LIST_DIR}/preamble.cmake")
-
-if(NOT EXISTS "${VOLEPSI_BUILD_DIR}")
-    message(FATAL_ERROR "failed to find the volePSI build directory. Looked at VOLEPSI_BUILD_DIR: ${VOLEPSI_BUILD_DIR}\n Please set it manually.")
-endif()
-
-include("${VOLEPSI_BUILD_DIR}/volePSIConfig.cmake")

--- a/secure-join/AggTree/AggTree.cpp
+++ b/secure-join/AggTree/AggTree.cpp
@@ -41,8 +41,8 @@ namespace secJoin
 
             if (dstShift2)
             {
-                setBytes(out0[i].subspan(0, dstShift2 / 8), 0);
-                setBytes(out1[i].subspan(0, dstShift2 / 8), 0);
+                osuCrypto::setBytes(out0[i].subspan(0, dstShift2 / 8), 0);
+                osuCrypto::setBytes(out1[i].subspan(0, dstShift2 / 8), 0);
             }
 
             perfectUnshuffle(inn, o0, o1);
@@ -666,7 +666,7 @@ namespace secJoin
                     {
                         auto ss0 = src[k].subspan(srcStart, size);
                         auto dd0 = dst[k].subspan(dstStart, size);
-                        secJoin::copyBytes(dd0, ss0);
+                        osuCrypto::copyBytes(dd0, ss0);
                     }
                 }
             };

--- a/secure-join/AggTree/Level.h
+++ b/secure-join/AggTree/Level.h
@@ -186,8 +186,8 @@ namespace secJoin
                 // for the first even number of rows split te values into left and right
                 for (; i < available2; i += 2, ++d)
                 {
-                    copyBytes(vals[0][d], src[i + 0].subspan(0, byteCount));
-                    copyBytes(vals[1][d], src[i + 1].subspan(0, byteCount));
+                    osuCrypto::copyBytes(vals[0][d], src[i + 0].subspan(0, byteCount));
+                    osuCrypto::copyBytes(vals[1][d], src[i + 1].subspan(0, byteCount));
 
                     assert(mLeftRight[0].mPreBit.size() > d / 8);
                     assert(mLeftRight[1].mPreBit.size() > d / 8);
@@ -200,8 +200,8 @@ namespace secJoin
                 if (available & 1)
                 {
                     assert(i == src.rows() - 1);
-                    copyBytes(vals[0][d], src[i].subspan(0, byteCount));
-                    setBytes(vals[1][d], 0);
+                    osuCrypto::copyBytes(vals[0][d], src[i].subspan(0, byteCount));
+                    osuCrypto::setBytes(vals[1][d], 0);
                     assert(mLeftRight[0].mPreBit.size() > d / 8);
                     *oc::BitIterator(mLeftRight[0].mPreBit.data(), d) = controlBits[i];
                     *oc::BitIterator(mLeftRight[1].mPreBit.data(), d) = 0;
@@ -212,8 +212,8 @@ namespace secJoin
                 // if there is space left over fill with zeros
                 for (; d < n / 2; ++d)
                 {
-                    setBytes(vals[0][d], 0);
-                    setBytes(vals[1][d], 0);
+                    osuCrypto::setBytes(vals[0][d], 0);
+                    osuCrypto::setBytes(vals[1][d], 0);
                     *oc::BitIterator(mLeftRight[0].mPreBit.data(), d) = 0;
                     *oc::BitIterator(mLeftRight[1].mPreBit.data(), d) = 0;
                 }
@@ -234,15 +234,15 @@ namespace secJoin
                 // std::cout << "d " << d << std::endl;
                 for (; i < available2 - 2; i += 2, ++d)
                 {
-                    copyBytes(vals[0][d], src[i + 0].subspan(0, byteCount));
-                    copyBytes(vals[1][d], src[i + 1].subspan(0, byteCount));
+                    osuCrypto::copyBytes(vals[0][d], src[i + 0].subspan(0, byteCount));
+                    osuCrypto::copyBytes(vals[1][d], src[i + 1].subspan(0, byteCount));
                     *oc::BitIterator(mLeftRight[0].mSufBit.data(), d) = controlBits[i + 1];
                     *oc::BitIterator(mLeftRight[1].mSufBit.data(), d) = controlBits[i + 2];
                 }
 
                 {
-                    copyBytes(vals[0][d], src[i + 0].subspan(0, byteCount));
-                    copyBytes(vals[1][d], src[i + 1].subspan(0, byteCount));
+                    osuCrypto::copyBytes(vals[0][d], src[i + 0].subspan(0, byteCount));
+                    osuCrypto::copyBytes(vals[1][d], src[i + 1].subspan(0, byteCount));
 
                     auto cLast = 0;
                     if (i + 2 < controlBits.size())
@@ -260,8 +260,8 @@ namespace secJoin
 
                 if (available & 1)
                 {
-                    copyBytes(vals[0][d], src[i + 0].subspan(0, byteCount));
-                    setBytes(vals[1][d], 0);
+                    osuCrypto::copyBytes(vals[0][d], src[i + 0].subspan(0, byteCount));
+                    osuCrypto::setBytes(vals[1][d], 0);
 
                     auto cLast = 0;
                     if (i + 1 < controlBits.size())
@@ -279,8 +279,8 @@ namespace secJoin
                 // if there is space left over fill with zeros
                 for (; d < n / 2; ++d)
                 {
-                    setBytes(vals[0][d], 0);
-                    setBytes(vals[1][d], 0);
+                    osuCrypto::setBytes(vals[0][d], 0);
+                    osuCrypto::setBytes(vals[1][d], 0);
                     *oc::BitIterator(mLeftRight[0].mPreBit.data(), d) = 0;
                     *oc::BitIterator(mLeftRight[1].mPreBit.data(), d) = 0;
                 }
@@ -361,7 +361,7 @@ namespace secJoin
                     {
                         auto d = dst.mData[i].subspan(dOffset, size);
                         auto s = src.mData[i].subspan(sOffset, size);
-                        copyBytes(d, s);
+                        osuCrypto::copyBytes(d, s);
                     }
                 };
             for (u64 j = 0; j < 2; ++j)

--- a/secure-join/AggTree/PerfectShuffle.h
+++ b/secure-join/AggTree/PerfectShuffle.h
@@ -86,10 +86,10 @@ namespace secJoin
 		if (output.size() != n8)
 		{
 			u16 x0 = 0, x1 = 0;
-			copyBytesMin(x0, input0.subspan(n8 / 2));
-			copyBytesMin(x1, input1.subspan(n8 / 2));
+			osuCrypto::copyBytesMin(x0, input0.subspan(n8 / 2));
+			osuCrypto::copyBytesMin(x1, input1.subspan(n8 / 2));
 			auto t = cPerfectShuffle(x0, x1);
-			copyBytesMin(output.subspan(n8), t);
+			osuCrypto::copyBytesMin(output.subspan(n8), t);
 		}
 	}
 
@@ -120,10 +120,10 @@ namespace secJoin
 		{
 			// auto rem = output0.size() - n8 / 2;
 			u32 t = 0;
-			copyBytesMin(t, input.subspan(n8));
+			osuCrypto::copyBytesMin(t, input.subspan(n8));
 			auto r = cPerfectUnshuffle(t);
-			copyBytesMin(output0.subspan(n8 / 2), r[0]);
-			copyBytesMin(output1.subspan(n8 / 2), r[1]);
+			osuCrypto::copyBytesMin(output0.subspan(n8 / 2), r[0]);
+			osuCrypto::copyBytesMin(output1.subspan(n8 / 2), r[1]);
 		}
 	}
 

--- a/secure-join/AggTree/PlainAggTree.cpp
+++ b/secure-join/AggTree/PlainAggTree.cpp
@@ -36,7 +36,7 @@ namespace secJoin
 
 			oc::Matrix<u8> v(ret[0].numEntries(), ret[0].bytesPerEntry());
 			for (u64 i = 0; i < v.rows(); ++i)
-				copyBytes(v[i], mInput[i]);
+				osuCrypto::copyBytes(v[i], mInput[i]);
 
 			share(v, ret[0].bitsPerEntry(), ret[0], ret[1], prng);
 

--- a/secure-join/CorGenerator/F4BitOtBatch.cpp
+++ b/secure-join/CorGenerator/F4BitOtBatch.cpp
@@ -110,8 +110,8 @@ namespace secJoin
 	//}
 	void F4BitOtBatch::SendBatch::mock(u64 batchIdx, u64 n)
 	{
-		//setBytes(add, 0);
-		//setBytes(mult, 0);
+		//osuCrypto::setBytes(add, 0);
+		//osuCrypto::setBytes(mult, 0);
 		//return;
 		assert(n % 128 == 0);
 		auto  m = n / 128;
@@ -123,7 +123,7 @@ namespace secJoin
 		if (1)
 		{
 			for (u64 j = 0; j < 4; ++j)
-				setBytes(mOts[j], 0);
+				osuCrypto::setBytes(mOts[j], 0);
 			return;
 		}
 
@@ -192,8 +192,8 @@ namespace secJoin
 	void F4BitOtBatch::RecvBatch::mock(u64 batchIdx, u64 n)
 	{
 
-		//setBytes(add, 0);
-		//setBytes(mult, 0);
+		//osuCrypto::setBytes(add, 0);
+		//osuCrypto::setBytes(mult, 0);
 		//return;
 		//throw RTE_LOC;
 		assert(n % 128 == 0);
@@ -203,9 +203,9 @@ namespace secJoin
 		mChoiceMsb.resize(m);
 		if (1)
 		{
-			setBytes(mOts, 0);
-			setBytes(mChoiceLsb, 0);
-			setBytes(mChoiceMsb, 0);
+			osuCrypto::setBytes(mOts, 0);
+			osuCrypto::setBytes(mChoiceLsb, 0);
+			osuCrypto::setBytes(mChoiceMsb, 0);
 			return;
 		}
 
@@ -454,7 +454,7 @@ namespace secJoin
 		auto msbIter8 = (u8*)mChoiceMsb.data();
 
 		auto shuffle = std::array<block, 16>{};
-		setBytes(shuffle, static_cast<u8>(1 << 7));
+		osuCrypto::setBytes(shuffle, static_cast<u8>(1 << 7));
 		for (u64 i = 0; i < 16; ++i)
 			shuffle[i].set<u8>(i, 0);
 
@@ -604,7 +604,7 @@ namespace secJoin
 		using block = oc::block;
 
 		auto shuffle = std::array<block, 16>{};
-		setBytes(shuffle, static_cast<char>(1 << 7));
+		osuCrypto::setBytes(shuffle, static_cast<char>(1 << 7));
 		for (u64 i = 0; i < 16; ++i)
 			shuffle[i].set<u8>(i, 0);
 

--- a/secure-join/CorGenerator/F4Vole/F4CoeffCtx.h
+++ b/secure-join/CorGenerator/F4Vole/F4CoeffCtx.h
@@ -155,7 +155,7 @@ namespace secJoin
         {
             static_assert(std::is_trivially_copyable<F>::value, "memset is used so must be trivially_copyable.");
             F r;
-            setBytes(r, 0);
+            osuCrypto::setBytes(r, 0);
             return r;
         }
 

--- a/secure-join/CorGenerator/OtBatch.cpp
+++ b/secure-join/CorGenerator/OtBatch.cpp
@@ -30,7 +30,7 @@ namespace secJoin
     void OtBatch::RecvOtBatch::mock(u64 batchIdx)
     {
         auto s = oc::mAesFixedKey.ecbEncBlock(oc::block(batchIdx, 0));
-        setBytes(mChoice.getSpan<u8>(), s.get<u8>(0));
+        osuCrypto::setBytes(mChoice.getSpan<u8>(), s.get<u8>(0));
 
         for (u32 i = 0; i < mMsg.size(); ++i)
         {

--- a/secure-join/CorGenerator/TritOtBatch.cpp
+++ b/secure-join/CorGenerator/TritOtBatch.cpp
@@ -115,8 +115,8 @@ namespace secJoin
 		{
 			for (u64 j = 0; j < 2; ++j)
 			{
-				setBytes(mLsb[j], 0);
-				setBytes(mMsb[j], 0);
+				osuCrypto::setBytes(mLsb[j], 0);
+				osuCrypto::setBytes(mMsb[j], 0);
 			}
 			return;
 		}
@@ -151,9 +151,9 @@ namespace secJoin
 		mMsb.resize(m);
 		if (0)
 		{
-			setBytes(mChoice, 0);
-			setBytes(mLsb, 0);
-			setBytes(mMsb, 0);
+			osuCrypto::setBytes(mChoice, 0);
+			osuCrypto::setBytes(mLsb, 0);
+			osuCrypto::setBytes(mMsb, 0);
 			return;
 		}
 		else

--- a/secure-join/Defines.h
+++ b/secure-join/Defines.h
@@ -94,68 +94,6 @@ namespace secJoin
 		coproto::enable_if_t<coproto::has_size_member_func<typename std::remove_reference<Container>::type>::value>
 		>> :
 		coproto::true_type {};
-		 
-
-    template<typename T>
-    auto asSpan(T&& t)
-    {
-        static_assert(std::is_pointer_v<T> == false);
-
-        if constexpr (std::is_same_v<std::remove_cvref_t<T>, oc::BitVector>)
-        {
-            return t.template getSpan<u8>();
-        }
-        if constexpr (is_container<T>::value)
-        {
-            using U = std::remove_reference_t<decltype(*t.data())>;
-            return span<U>(t.data(), t.size());
-        }
-        else if constexpr(std::is_trivial_v<std::remove_reference_t<T>>)
-        {
-            return std::span<std::remove_reference_t<T>, 1>(&t, &t+1);
-        }
-        else
-        {
-            static_assert(
-                is_container<T>::value || 
-                std::is_trivial_v<std::remove_reference_t<T>>
-                );
-        }
-    }
-
-    template<typename D, typename S>
-    OC_FORCEINLINE void copyBytes(D&& dst,S&& src)
-    {
-        auto d = asSpan(dst);
-        auto s = asSpan(src);
-        if(d.size_bytes() != s.size_bytes())
-            throw RTE_LOC;
-        static_assert(std::is_trivially_copyable_v<std::remove_reference_t<decltype(*d.data())>>);
-        static_assert(std::is_trivially_copyable_v<std::remove_reference_t<decltype(*s.data())>>);
-        if(d.size())
-            std::memcpy(d.data(), s.data(), d.size_bytes());
-    }
-
-    template<typename D, typename S>
-    OC_FORCEINLINE void copyBytesMin(D&& dst, S&& src)
-    {
-        auto d = asSpan(dst);
-        auto s = asSpan(src);
-        auto size = std::min(s.size_bytes(), d.size_bytes());
-        static_assert(std::is_trivially_copyable_v<std::remove_reference_t<decltype(*d.data())>>);
-        static_assert(std::is_trivially_copyable_v<std::remove_reference_t<decltype(*s.data())>>);
-        if(size)
-            std::memcpy(d.data(), s.data(), size);
-    }
-
-    template<typename D>
-    OC_FORCEINLINE void setBytes(D&& dst, char v)
-    {
-        auto d = asSpan(dst);
-        static_assert(std::is_trivially_copyable_v<std::remove_reference_t<decltype(*d.data())>>);
-        if(d.size())
-            std::memset(d.data(), v, d.size_bytes());
-    }
 
     inline std::string hex(oc::span<const u8> d)
     {

--- a/secure-join/Join/OmJoin.cpp
+++ b/secure-join/Join/OmJoin.cpp
@@ -31,8 +31,8 @@ namespace secJoin
 			auto d0 = k.subspan(0, size0);
 			auto d1 = k.subspan(size0);
 			assert(d1.data() + d1.size() == k.data() + k.size());
-			copyBytes(d0, leftJoinCol.mCol.mData);
-			copyBytes(d1, rightJoinCol.mCol.mData);
+			osuCrypto::copyBytes(d0, leftJoinCol.mCol.mData);
+			osuCrypto::copyBytes(d1, rightJoinCol.mCol.mData);
 			return keys;
 
 		}
@@ -128,7 +128,7 @@ namespace secJoin
 		sKeys.resize(data.rows() + 1, keyBitCount);
 		for (u64 i = 0; i < n; ++i)
 		{
-			copyBytes(sKeys[i+1], data[i].subspan(keyByteOffset, keyByteSize));
+			osuCrypto::copyBytes(sKeys[i+1], data[i].subspan(keyByteOffset, keyByteSize));
 		}
 
 		mControlBitGmw.setInput(0, sKeys.subMatrix(0, n));
@@ -163,11 +163,11 @@ namespace secJoin
 			assert(divCeil(offsets[j].mSize, 8) == size);
 			for (u64 i = 1; i < n; ++i)
 			{
-				copyBytes(d0.subspan(0, size), src.subspan(0, size));
+				osuCrypto::copyBytes(d0.subspan(0, size), src.subspan(0, size));
 				src = src.subspan(size);
 				d0 = d0.subspan(dst.cols());
 			}
-			copyBytes(d0.subspan(0, size), src.subspan(0, size));
+			osuCrypto::copyBytes(d0.subspan(0, size), src.subspan(0, size));
 
 		}
 	}
@@ -281,7 +281,7 @@ namespace secJoin
 					dsts[j] = dsts[j].subspan(sizes[j]);
 					srcs[j] = srcs[j].subspan(srcStep);
 				}
-				copyBytes(dsts[j].subspan(0, sizes[j]), srcs[j].subspan(0, sizes[j]));
+				osuCrypto::copyBytes(dsts[j].subspan(0, sizes[j]), srcs[j].subspan(0, sizes[j]));
 			}
 		}
 	}
@@ -389,7 +389,7 @@ namespace secJoin
 		out.resize(data.rows(), data.bitsPerEntry());
 		for (u64 i = 0; i < data.rows(); ++i)
 		{
-			copyBytes(out[i].subspan(0, offset), data[i].subspan(0, offset));
+			osuCrypto::copyBytes(out[i].subspan(0, offset), data[i].subspan(0, offset));
 			out(i, offset) = temp(i);
 		}
 	}
@@ -402,7 +402,7 @@ namespace secJoin
 		out.resize(n, m + 8);
 		for (u64 i = 0; i < n; ++i)
 		{
-			copyBytes(out[i].subspan(0, m8), data[i].subspan(0, m8));
+			osuCrypto::copyBytes(out[i].subspan(0, m8), data[i].subspan(0, m8));
 			out(i, m8) = choice(i);
 		}
 	}

--- a/secure-join/Join/OoJoin.cpp
+++ b/secure-join/Join/OoJoin.cpp
@@ -222,7 +222,7 @@ namespace secJoin
 				for (u64 j = 0; j < selects.size(); ++j)
 				{
 					auto src = selects[j].mCol.mData[inputIdx];
-					copyBytes(dest.subspan(0, src.size()), src);
+					osuCrypto::copyBytes(dest.subspan(0, src.size()), src);
 					dest = dest.subspan(src.size());
 					// memcpy(dest, src, strides[j]);
 					// dest += strides[j];

--- a/secure-join/Join/Table.cpp
+++ b/secure-join/Join/Table.cpp
@@ -32,7 +32,7 @@ namespace secJoin
 				for (u64 j = 0; j < out.cols(); j++)
 				{
 					auto bytes = out.mColumns[j].getByteCount();
-					copyBytes(out.mColumns[j].mData[curPtr], data.mData[i].subspan(byteStartIdx, bytes));
+					osuCrypto::copyBytes(out.mColumns[j].mData[curPtr], data.mData[i].subspan(byteStartIdx, bytes));
 					byteStartIdx += bytes;
 				}
 				curPtr++;
@@ -115,7 +115,7 @@ namespace secJoin
 					if (mColumns[j].mBitCount > 64)
 						throw RTE_LOC; // too big of an int to serialize
 					i64 v = 0;
-					copyBytesMin(v, mColumns[j].mData[i]);
+					osuCrypto::copyBytesMin(v, mColumns[j].mData[i]);
 					out << v << " ";
 				}
 				else if (mColumns[j].mType == ColumnType::Boolean)
@@ -196,7 +196,7 @@ namespace secJoin
 					if (std::to_string(v) != buffer)
 						throw RTE_LOC;
 
-					copyBytesMin(mColumns[j].mData[i], v);
+					osuCrypto::copyBytesMin(mColumns[j].mData[i], v);
 				}
 				else if(mColumns[j].mType == ColumnType::Boolean)
 				{
@@ -301,7 +301,7 @@ namespace secJoin
 				{
 					for (u64 j = 0; j < cols(); j++)
 					{
-						copyBytes(
+						osuCrypto::copyBytes(
 							mColumns[j].mData[curPtr],
 							mColumns[j].mData[i]);
 					}
@@ -374,7 +374,7 @@ namespace secJoin
 		{
 			inputs[0][0] = mIsActive[j];
 			for (u64 i = 0; i < inputColumns.size(); ++i)
-				copyBytes(inputs[1 + i], mColumns[inputColumns[i]].mData[j]);
+				osuCrypto::copyBytes(inputs[1 + i], mColumns[inputColumns[i]].mData[j]);
 
 			cir.evaluate(inputs, outputs);
 			mIsActive[j] = outputs[0][0];
@@ -419,7 +419,7 @@ namespace secJoin
 	//            for (oc::u64 colNum = 0; colNum < tb.cols(); colNum++)
 	//            {
 	//                u64 bytes = tb.mColumns[colNum].getByteCount();
-	//                copyBytes(
+	//                osuCrypto::copyBytes(
 	//                    tb.mColumns[colNum].mData[rowPtr],
 	//                    buffer.subspan(buffptr, bytes));
 	//                buffptr += bytes;
@@ -445,19 +445,19 @@ namespace secJoin
 	//        {
 	//            if (tb.mColumns[colNum].getTypeID() == ColumnType::String)
 	//            {
-	//                copyBytesMin(tb.mColumns[colNum].mData[rowNum], word);
+	//                osuCrypto::copyBytesMin(tb.mColumns[colNum].mData[rowNum], word);
 	//            }
 	//            else if (tb.mColumns[colNum].getTypeID() == ColumnType::Int)
 	//            {
 	//                if (tb.mColumns[colNum].getByteCount() <= 4)
 	//                {
 	//                    oc::i32 number = stoi(word);
-	//                    copyBytes(tb.mColumns[colNum].mData[rowNum], number);
+	//                    osuCrypto::copyBytes(tb.mColumns[colNum].mData[rowNum], number);
 	//                }
 	//                else if (tb.mColumns[colNum].getByteCount() <= 8)
 	//                {
 	//                    oc::i64 number = stoll(word);
-	//                    copyBytes(tb.mColumns[colNum].mData[rowNum], number);
+	//                    osuCrypto::copyBytes(tb.mColumns[colNum].mData[rowNum], number);
 	//                }
 	//                else
 	//                {
@@ -528,7 +528,7 @@ namespace secJoin
 		u64 m = avgCol.size();
 		assert(row < out.rows());
 		// Copying the groupby column
-		copyBytes(
+		osuCrypto::copyBytes(
 			out.mColumns[0].mData[row],
 			groupByCol.mCol.mData[row]);
 
@@ -536,13 +536,13 @@ namespace secJoin
 		for (u64 col = 0; col < m; col++)
 		{
 			assert(out.mColumns.at(col + 1).mData.bytesPerEntry() == inputs.at(2 * col).sizeBytes());
-			copyBytes(
+			osuCrypto::copyBytes(
 				out.mColumns.at(col + 1).mData[row],
 				inputs.at(2 * col));
 		}
 
 		// Copying the ones column 
-		copyBytes(
+		osuCrypto::copyBytes(
 			out.mColumns.at(m + 1).mData[row],
 			inputs.at(2 * m));
 
@@ -800,7 +800,7 @@ namespace secJoin
 				// auto size = ret.mColumns[j].mData.cols();
 				// m emcpy(dst, src, size);
 
-				copyBytes(ret.mColumns.at(j).mData[d], select.at(j).mCol.mData[I.at(i).at(lr)]);
+				osuCrypto::copyBytes(ret.mColumns.at(j).mData[d], select.at(j).mCol.mData[I.at(i).at(lr)]);
 			}
 			ret.mIsActive.at(d) = 1;
 
@@ -841,7 +841,7 @@ namespace secJoin
 					if (t.mColumns[j].getBitCount() > 64)
 						throw RTE_LOC;
 					i64 v = 0;
-					copyBytesMin(v, t.mColumns[j].mData[i]);
+					osuCrypto::copyBytesMin(v, t.mColumns[j].mData[i]);
 					printElem(v);
 				}
 				else

--- a/secure-join/Perm/InsecurePerm.h
+++ b/secure-join/Perm/InsecurePerm.h
@@ -141,9 +141,9 @@ namespace secJoin
 		for (u64 i = 0; i < n; ++i)
 		{
 			if (op == PermOp::Regular)
-				copyBytes(x2Perm[i], x2[pi[i]]);
+				osuCrypto::copyBytes(x2Perm[i], x2[pi[i]]);
 			else
-				copyBytes(x2Perm[pi[i]], x2[i]);
+				osuCrypto::copyBytes(x2Perm[pi[i]], x2[i]);
 		}
 
 		for (u64 i = 0; i < sout.rows(); ++i)

--- a/secure-join/Perm/LowMCPerm.cpp
+++ b/secure-join/Perm/LowMCPerm.cpp
@@ -56,7 +56,7 @@ namespace secJoin
 		dst.mDelta.resize(mN, divCeil(mBytesPerRow, sizeof(block)));
 		for (u64 i = 0; i < mN; ++i)
 		{
-			copyBytesMin(dst.mDelta[i], d.subspan(i * blocksPerRow, blocksPerRow));
+			osuCrypto::copyBytesMin(dst.mDelta[i], d.subspan(i * blocksPerRow, blocksPerRow));
 		}
 	}
 
@@ -107,7 +107,7 @@ namespace secJoin
 		dst.mA.resize(mN, divCeil(mBytesPerRow, sizeof(block)));
 		for (u64 i = 0; i < mN; ++i)
 		{
-			copyBytesMin(dst.mB[i], b.subspan(i * blocksPerRow, blocksPerRow));
+			osuCrypto::copyBytesMin(dst.mB[i], b.subspan(i * blocksPerRow, blocksPerRow));
 		}
 
 		std::vector<lowBlock> a(blocksPerRow);
@@ -121,7 +121,7 @@ namespace secJoin
 				a.data()[j] = lowMc.encrypt(a.data()[j]);
 			}
 
-			copyBytesMin(dst.mA[i], a);
+			osuCrypto::copyBytesMin(dst.mA[i], a);
 		}
 
 	}

--- a/secure-join/Perm/Permutation.h
+++ b/secure-join/Perm/Permutation.h
@@ -135,7 +135,7 @@ namespace secJoin
 
 					for (; i < size(); i++)
 					{
-						copyBytes(dst[i], src[mPi[i]]);
+						osuCrypto::copyBytes(dst[i], src[mPi[i]]);
 					}
 				}
 				else
@@ -200,7 +200,7 @@ namespace secJoin
 
 					for (; i < size(); i++)
 					{
-						copyBytes(dst[mPi[i]], src[i]);
+						osuCrypto::copyBytes(dst[mPi[i]], src[i]);
 					}
 				}
 				else

--- a/secure-join/Prf/AltModKeyMult.cpp
+++ b/secure-join/Prf/AltModKeyMult.cpp
@@ -310,7 +310,7 @@ namespace secJoin
 			else
 			{
 				AltModPrf::KeyType k;
-				setBytes(k, 0);
+				osuCrypto::setBytes(k, 0);
 				co_await sock.send(k);
 			}
 

--- a/secure-join/Prf/AltModKeyMult.h
+++ b/secure-join/Prf/AltModKeyMult.h
@@ -194,7 +194,7 @@ namespace secJoin
         {
             mKeyRecvOTs.clear();
             mRecvKeyReq.clear();
-            setBytes(mKey, 0);
+            osuCrypto::setBytes(mKey, 0);
         }
 
         // starts the preprocessing, if any.

--- a/secure-join/Prf/AltModPrf.cpp
+++ b/secure-join/Prf/AltModPrf.cpp
@@ -7,7 +7,7 @@ namespace secJoin
 
 	auto makeAltModWPrfB() {
 		std::array<block, 128> r;
-		setBytes(r, 0);
+		osuCrypto::setBytes(r, 0);
 		PRNG prng(block(234532451234512134, 214512345123455437));
 		for (u64 i = 0; i < r.size(); ++i)
 		{
@@ -22,7 +22,7 @@ namespace secJoin
 		oc::Matrix<u8> g(128, sizeof(block)), gt(128, sizeof(block));
 		g.resize(128, sizeof(block));
 		for (u64 i = 0; i < 128; ++i)
-			copyBytes(g[i], AltModPrf::mB[i]);
+			osuCrypto::copyBytes(g[i], AltModPrf::mB[i]);
 		oc::transpose(g, gt);
 		F2LinearCode r;
 		r.init(gt);
@@ -313,12 +313,12 @@ namespace secJoin
 			// TODO, make this branch free.
 			if (bit(mExpandedKey, i))
 			{
-				copyBytes(xk0[i], xt[i]);
+				osuCrypto::copyBytes(xk0[i], xt[i]);
 			}
 			else
-				setBytes(xk0[i], 0);
+				osuCrypto::setBytes(xk0[i], 0);
 
-			setBytes(xk1[i], 0);
+			osuCrypto::setBytes(xk1[i], 0);
 		}
 
 		// u = A * xk mod 3

--- a/secure-join/Prf/F2LinearCode.cpp
+++ b/secure-join/Prf/F2LinearCode.cpp
@@ -22,7 +22,7 @@ namespace secJoin
         mG.setZero();
         for (u64 i = 0; i < g.rows(); ++i)
         {
-            copyBytes(mG[i], g[i]);
+            osuCrypto::copyBytes(mG[i], g[i]);
         }
 
         generateSubcodes();

--- a/secure-join/Prf/F3LinearCode.h
+++ b/secure-join/Prf/F3LinearCode.h
@@ -131,11 +131,11 @@ namespace secJoin
                 {
                     static_assert(is_container<oc::span<block>&>::value);
                     auto pi = mPerms.back()[i];
-                    copyBytes(
+                    osuCrypto::copyBytes(
                         outLsb[i].subspan(begin, s), 
                         lsb[pi].subspan(begin, s));
 
-                    copyBytes(
+                    osuCrypto::copyBytes(
                         outMsb[i].subspan(begin, s),
                         msb[pi].subspan(begin, s));
                 }

--- a/secure-join/Sort/BitInjection.cpp
+++ b/secure-join/Sort/BitInjection.cpp
@@ -9,7 +9,7 @@ namespace secJoin
 
 
 		if (bitCount == 32)
-			copyBytes(out, in);
+			osuCrypto::copyBytes(out, in);
 		else
 		{
 			auto n = oc::divCeil(bitCount, 8);
@@ -24,7 +24,7 @@ namespace secJoin
 	{
 
 		if (bitCount == 32)
-			copyBytes(out, in);
+			osuCrypto::copyBytes(out, in);
 		else
 		{
 			auto n = oc::divCeil(bitCount, 8);

--- a/secure-join/TableOps/Extract.cpp
+++ b/secure-join/TableOps/Extract.cpp
@@ -70,7 +70,7 @@ namespace secJoin {
 			auto d = dst.mData[i];
 			for (u64 j = 0; j < input.size(); ++j)
 			{
-				copyBytes(d.subspan(0, input[j].cols()), input[j][i]);
+				osuCrypto::copyBytes(d.subspan(0, input[j].cols()), input[j][i]);
 				d = d.subspan(input[j].cols());
 			}
 		}
@@ -102,7 +102,7 @@ namespace secJoin {
 			auto d = input[i];
 			for (u64 j = 0; j < output.size(); ++j)
 			{
-				copyBytes(output[j][i], d.subspan(0, output[j].cols()));
+				osuCrypto::copyBytes(output[j][i], d.subspan(0, output[j].cols()));
 				d = d.subspan(output[j].cols());
 			}
 		}
@@ -174,7 +174,7 @@ namespace secJoin {
 				auto src = combined[i].subspan(1);
 				for (u64 j = 0; j < output.size(); ++j)
 				{
-					copyBytes((*output[j])[d], src.subspan(0, output[j]->bytesPerEntry()));
+					osuCrypto::copyBytes((*output[j])[d], src.subspan(0, output[j]->bytesPerEntry()));
 					src = src.subspan(output[j]->bytesPerEntry());
 				}
 				++d;

--- a/secure-join/TableOps/GroupBy.cpp
+++ b/secure-join/TableOps/GroupBy.cpp
@@ -25,8 +25,8 @@ namespace secJoin
 
 		for (u64 i = 0; i < n; ++i)
 		{
-			copyBytes(grpByData[i], data[i].subspan(offsets[0].mStart / 8, grpByData.bytesPerEntry()));
-			copyBytes(compressKeys[i], data[i].subspan(offsets[1].mStart / 8, compressKeys.bytesPerEntry()));
+			osuCrypto::copyBytes(grpByData[i], data[i].subspan(offsets[0].mStart / 8, grpByData.bytesPerEntry()));
+			osuCrypto::copyBytes(compressKeys[i], data[i].subspan(offsets[1].mStart / 8, compressKeys.bytesPerEntry()));
 			
 			*oc::BitIterator((u8*)actFlag.data(i), 0) =
 				*oc::BitIterator((u8*)data.data(i), offsets[2].mStart);
@@ -56,7 +56,7 @@ namespace secJoin
 		assert(rows == actFlagVec.size());
 		for (u64 i = 0; i < keys.rows(); ++i)
 		{
-			copyBytes(keys[i].subspan(0, grpByBytes), grpByData[i]);
+			osuCrypto::copyBytes(keys[i].subspan(0, grpByBytes), grpByData[i]);
 			*oc::BitIterator((u8*)keys.data(i), grpByBits) =
 				*oc::BitIterator((u8*)&actFlagVec[0] + i, 0);
 		}
@@ -466,7 +466,7 @@ namespace secJoin
 			// Copying the average columns
 			for (u64 j = 0; j < offsets.size() - 2; j++)
 			{
-				copyBytes(
+				osuCrypto::copyBytes(
 					out.mColumns[j + 1].mData[i],
 					data[i].subspan(offsets[j].mStart / 8,
 						out.mColumns[j + 1].getByteCount()));
@@ -474,7 +474,7 @@ namespace secJoin
 			}
 
 			// Storing the Group By Column
-			copyBytes(
+			osuCrypto::copyBytes(
 				out.mColumns[0].mData[i],
 				data[i].subspan(offsets[offsets.size() - 2].mStart / 8,
 					out.mColumns[0].getByteCount()));
@@ -539,7 +539,7 @@ namespace secJoin
 		keyBitCount = keys.bitsPerEntry();
 
 		sKeys.resize(n + 1, keyBitCount);
-		copyBytes(sKeys.subMatrix(1), keys.subMatrix(0, n));
+		osuCrypto::copyBytes(sKeys.subMatrix(1), keys.subMatrix(0, n));
 
 		mControlBitGmw.setInput(0, sKeys.subMatrix(0, n));
 		mControlBitGmw.setInput(1, sKeys.subMatrix(1, n));

--- a/secure-join/TableOps/Where.cpp
+++ b/secure-join/TableOps/Where.cpp
@@ -83,7 +83,7 @@ namespace secJoin {
 		if(input.rows() != mRows)
 			throw RTE_LOC;
 		for (auto i : oc::rng(input.mColumns.size()))
-			if (input.mColumns[i] != mColumns[i])
+			if (input.mColumns[i].getColumnInfo() != mColumns[i])
 				throw std::runtime_error(LOCATION);
 
 		// set the inputs

--- a/secure-join/TableOps/WhereParser.cpp
+++ b/secure-join/TableOps/WhereParser.cpp
@@ -127,14 +127,14 @@ namespace secJoin
 
 		auto intPrint = [](const oc::BitVector& v) {
 			i64 val = 0;
-			copyBytesMin(val, v);
+			osuCrypto::copyBytesMin(val, v);
 			val = signExtend(val, v.size() - 1);
 			return std::to_string(val);
 			};
 
 		auto strPrint = [](const oc::BitVector& v) {
 			std::string s(v.sizeBytes(), 'a');
-			copyBytes(s, v);
+			osuCrypto::copyBytes(s, v);
 			return s;
 			};
 

--- a/secure-join/Util/Trim.h
+++ b/secure-join/Util/Trim.h
@@ -24,7 +24,7 @@ namespace secJoin
 		const span<T>& b,
 		u64 bitCount)
 	{
-		return areEqualImpl(asSpan<u8>(a), asSpan<u8>(b), bitCount);
+		return areEqualImpl(osuCrypto::asSpan<u8>(a), osuCrypto::asSpan<u8>(b), bitCount);
 	}
 
 	bool areEqualImpl(

--- a/tests/AggTree_Tests.cpp
+++ b/tests/AggTree_Tests.cpp
@@ -57,7 +57,7 @@ void eval(BetaCircuit& cir,
                 inputs[j][i].randomize(prng);
                 
                 //m emcpy(in[j].data(), inputs[j][i].data(), inputs[j][i].sizeBytes());
-                copyBytes(in[j], inputs[j][i]);
+                osuCrypto::copyBytes(in[j], inputs[j][i]);
             }
 
             share(in, cir.mInputs[i].size(), sInputs[i][0], sInputs[i][1], prng);
@@ -532,12 +532,12 @@ BinMatrix perfectShuffle(const BinMatrix& x0, const BinMatrix& x1)
     BinMatrix mR(x0.numEntries() + x1.numEntries(), x0.bitsPerEntry());
     for (u64 i = 0; i < x0.numEntries(); ++i)
     {
-        copyBytes(mR[i * 2], x0[i]);
+        osuCrypto::copyBytes(mR[i * 2], x0[i]);
         //m emcpy(mR.data(i * 2), x0.data(i), mR.bytesPerEntry());
     }
     for (u64 i = 0; i < x1.numEntries(); ++i)
     {
-        copyBytes(mR[i * 2 + 1], x1[i]);
+        osuCrypto::copyBytes(mR[i * 2 + 1], x1[i]);
         // m emcpy(mR.data(i * 2 + 1), x1.data(i), mR.bytesPerEntry());
     }
     return mR;
@@ -747,8 +747,8 @@ void AggTree_dup_singleSetLeaves_Test()
                         expS.resize(nn, m);
                         expPreC.resize(nn, 1);
 
-                        copyBytes(expS.subMatrix(mR, mN - mN0), s.subMatrix(mN0));
-                        copyBytes(expPreC.subMatrix(mR, mN - mN0), c.subMatrix(mN0));
+                        osuCrypto::copyBytes(expS.subMatrix(mR, mN - mN0), s.subMatrix(mN0));
+                        osuCrypto::copyBytes(expPreC.subMatrix(mR, mN - mN0), c.subMatrix(mN0));
 
                         expSufC = expPreC; expSufC.resize(nn, 1);
                         for (u64 i = mR + 1; i < expSufC.size(); ++i)

--- a/tests/GroupBy_Test.cpp
+++ b/tests/GroupBy_Test.cpp
@@ -227,7 +227,7 @@ void GroupBy_getControlBits_Test(const oc::CLP& cmd)
         exp[i] = prng.getBit();
         if (exp[i])
         {
-            copyBytes(keys[i], keys[i - 1]);
+            osuCrypto::copyBytes(keys[i], keys[i - 1]);
             // m emcpy(keys.data(i), keys.data(i - 1), keys.cols());
         }
     }

--- a/tests/LowMCPerm_Test.cpp
+++ b/tests/LowMCPerm_Test.cpp
@@ -36,7 +36,7 @@ void LowMC_eval_test(const oc::CLP& cmd)
 	{
 		k[i].resize(n, sizeBlock);
 		for (u64 j = 0; j < n; ++j)
-			copyBytes(k[i][j], bytes(lowMc.roundkeys[i]));
+			osuCrypto::copyBytes(k[i][j], bytes(lowMc.roundkeys[i]));
 	}
 
 	PRNG prng0(oc::block(0, 0));
@@ -79,8 +79,8 @@ void LowMC_eval_test(const oc::CLP& cmd)
 			y0(i, j) ^= y1(i, j);
 
 		LowMC2<>::block xx, zz;
-		copyBytes(bytes(xx), x[i]);
-		copyBytes(bytes(zz), y0[i]);
+		osuCrypto::copyBytes(bytes(xx), x[i]);
+		osuCrypto::copyBytes(bytes(zz), y0[i]);
 		auto yy = lowMc.encrypt(xx);
 		if (yy != zz)
 		{

--- a/tests/OmJoin_Test.cpp
+++ b/tests/OmJoin_Test.cpp
@@ -66,7 +66,7 @@ void OmJoin_getControlBits_Test(const oc::CLP& cmd)
         exp[i] = prng.getBit();
         if (exp[i])
         {
-			copyBytes(k[i].subspan(offset), k[i - 1].subspan(offset));
+			osuCrypto::copyBytes(k[i].subspan(offset), k[i - 1].subspan(offset));
             //me mcpy(k.data(i) + offset, k.data(i - 1) + offset, k.cols() - offset);
         }
     }
@@ -309,7 +309,7 @@ void OmJoin_join_Test(const oc::CLP& cmd)
         if (keys.insert(ii).second == false)
             throw RTE_LOC;
         //m emcpy(&L.mColumns[0].mData.mData(i, 0), &ii, L.mColumns[0].mData.bytesPerEntry());
-		copyBytesMin(L.mColumns[0].mData.mData[i], ii);
+		osuCrypto::copyBytesMin(L.mColumns[0].mData.mData[i], ii);
         L.mColumns[1].mData.mData(i, 0) = i % 4;
         L.mColumns[1].mData.mData(i, 1) = i % 3;
     }
@@ -320,7 +320,7 @@ void OmJoin_join_Test(const oc::CLP& cmd)
         //if (k2.insert(ii).second == false)
         //    throw RTE_LOC;
         //m emcpy(&R.mColumns[0].mData.mData(i, 0), &ii, R.mColumns[0].mData.bytesPerEntry());
-		copyBytesMin(R.mColumns[0].mData.mData[i], ii);
+		osuCrypto::copyBytesMin(R.mColumns[0].mData.mData[i], ii);
         // R.mColumns[0].mData.mData(i, 0) = i * 2;
         R.mColumns[1].mData.mData(i) = i % 3;
     }
@@ -428,10 +428,10 @@ void OmJoin_join_BigKey_Test(const oc::CLP& cmd)
         // u64 k 
         auto ii = i * 3;
         assert(sizeof(ii) <= buff.size());
-        copyBytesMin(buff, ii);
+        osuCrypto::copyBytesMin(buff, ii);
         //m emcpy(buff.data(), &ii, sizeof(ii));
         //m emcpy(&L.mColumns[0].mData.mData(i, 0), buff.data(), L.mColumns[0].mData.bytesPerEntry());
-		copyBytes(L.mColumns[0].mData.mData[i], buff);
+		osuCrypto::copyBytes(L.mColumns[0].mData.mData[i], buff);
         L.mColumns[1].mData.mData(i, 0) = i % 4;
         //L.mColumns[1].mData.mData(i, 1) = i % 3;
     }
@@ -440,11 +440,11 @@ void OmJoin_join_BigKey_Test(const oc::CLP& cmd)
     {
         auto ii = i / 2 * 4;
         assert(sizeof(ii) <= buff.size());
-		copyBytesMin(buff, ii);
+		osuCrypto::copyBytesMin(buff, ii);
 
         //m emcpy(buff.data(), &ii, sizeof(ii));
         //m emcpy(&R.mColumns[0].mData.mData(i, 0), buff.data(), R.mColumns[0].mData.bytesPerEntry());
-		copyBytesMin(R.mColumns[0].mData[i], buff);
+		osuCrypto::copyBytesMin(R.mColumns[0].mData[i], buff);
         // R.mColumns[0].mData.mData(i, 0) = i * 2;
         R.mColumns[1].mData.mData(i) = i % 3;
     }
@@ -768,7 +768,7 @@ void OmJoin_join_round_Test(const oc::CLP& cmd)
     for (u64 i = 0; i < nL; ++i)
     {
         // u64 k 
-        copyBytesMin(L.mColumns[0].mData.mData[i], i);
+        osuCrypto::copyBytesMin(L.mColumns[0].mData.mData[i], i);
         L.mColumns[1].mData.mData(i, 0) = i % 4;
         //L.mColumns[1].mData.mData(i, 1) = i % 3;
     }
@@ -776,7 +776,7 @@ void OmJoin_join_round_Test(const oc::CLP& cmd)
     for (u64 i = 0; i < nR; ++i)
     {
         auto ii = i * 2;
-        copyBytesMin(R.mColumns[0].mData.mData[i], ii);
+        osuCrypto::copyBytesMin(R.mColumns[0].mData.mData[i], ii);
         // R.mColumns[0].mData.mData(i, 0) = i * 2;
         R.mColumns[1].mData.mData(i) = i % 3;
     }

--- a/tests/RadixSort_Test.cpp
+++ b/tests/RadixSort_Test.cpp
@@ -486,12 +486,12 @@ void RadixSort_genBitPerm_test(const oc::CLP& cmd)
                             ke[jj](i) = v;
 
                             u64 kk = 0;
-                            copyBytesMin(kk, k[i]);
+                            osuCrypto::copyBytesMin(kk, k[i]);
                             //m emcpy(&kk, k[i].data(), k[i].size());
 
                             kk = kk << shift | v;
 
-							copyBytesMin(k[i], kk);
+							osuCrypto::copyBytesMin(k[i], kk);
                             // m emcpy(k[i].data(), &kk, k[i].size());
 
                             vals[v].push_back(i);
@@ -581,7 +581,7 @@ void RadixSort_genBitPerm_test(const oc::CLP& cmd)
 //    std::cout << "send buffers: " << std::endl;
 //    for (auto& b : s0.mImpl->mSendBuffers)
 //    {
-//        std::cout << "name: " << name(*b) << " local: " << b->mLocalId << " remote: " << (i32)b->mRemoteId << " size: " << b->mSendOps2_.begin()->mSendBuff.asSpan().size() << std::endl;
+//        std::cout << "name: " << name(*b) << " local: " << b->mLocalId << " remote: " << (i32)b->mRemoteId << " size: " << b->mSendOps2_.begin()->mSendBuff.osuCrypto::asSpan().size() << std::endl;
 //    }
 //
 //
@@ -630,7 +630,7 @@ void RadixSort_genBitPerm_test(const oc::CLP& cmd)
 //    printStatus(s1);
 //    //for (auto& b : s0.mImpl->m)
 //    //{
-//    //    std::cout << "local: " << b->mLocalId << " remote: " << b->mRemoteId << " size: " << b->mSendOps2_.begin()->mSendBuff.asSpan().size() << std::endl;
+//    //    std::cout << "local: " << b->mLocalId << " remote: " << b->mRemoteId << " size: " << b->mSendOps2_.begin()->mSendBuff.osuCrypto::asSpan().size() << std::endl;
 //    //}
 //
 //}
@@ -685,7 +685,7 @@ void RadixSort_genPerm_test(const oc::CLP& cmd)
                         u64 v = prng.get<u64>() & mask;
                         k64[i] = v;
                         // m emcpy(k[i].data(), &v, k[i].size());
-						copyBytesMin(k[i], v);
+						osuCrypto::copyBytesMin(k[i], v);
                     }
 
                     std::stable_sort(exp.begin(), exp.end(),
@@ -768,7 +768,7 @@ void RadixSort_mock_test(const oc::CLP& cmd)
                     u64 v = prng.get<u64>() & mask;
                     k64[i] = v;
                     //m emcpy(k[i].data(), &v, k[i].size());
-					copyBytesMin(k[i], v);
+					osuCrypto::copyBytesMin(k[i], v);
                 }
 
                 std::stable_sort(exp.begin(), exp.end(),

--- a/tests/Where_Test.cpp
+++ b/tests/Where_Test.cpp
@@ -93,14 +93,14 @@ void where_cir_test(const oc::CLP& cmd)
 	for (u64 i = 0; i < n; ++i)
 	{
 		table.mIsActive[i] = 1;//prng.getBit();
-		copyBytesMin(table.mColumns[0].mData.mData[i], i);
+		osuCrypto::copyBytesMin(table.mColumns[0].mData.mData[i], i);
 
 		if ((i % 3) == 0)
-			copyBytesMin(table.mColumns[1].mData.mData[i], std::string("hello world"));
+			osuCrypto::copyBytesMin(table.mColumns[1].mData.mData[i], std::string("hello world"));
 		else if ((i % 3) == 1)
-			copyBytesMin(table.mColumns[1].mData.mData[i], std::string("goodbye world"));
+			osuCrypto::copyBytesMin(table.mColumns[1].mData.mData[i], std::string("goodbye world"));
 		else
-			copyBytesMin(table.mColumns[1].mData.mData[i], std::string("what world"));
+			osuCrypto::copyBytesMin(table.mColumns[1].mData.mData[i], std::string("what world"));
 
 		bool w = (i % 3 < 2) && (((i ^ (i >> 1)) & 1));
 		exp[i] = (table.mIsActive[i] == 1) && w;
@@ -278,7 +278,7 @@ void WhereParser_genWhBundle_Test(const oc::CLP& cmd)
 	//    {
 	//        BitVector bitVector = wh.mWhBundle[i].mVal;
 	//        oc::u64 exp = 0;
-	//        copyBytesMin(exp, bitVector);
+	//        osuCrypto::copyBytesMin(exp, bitVector);
 	//        oc::u64 act = stoll(literals[i]);
 
 	//        if (act != exp)
@@ -290,7 +290,7 @@ void WhereParser_genWhBundle_Test(const oc::CLP& cmd)
 	//        std::string exp;
 	//        exp.resize(bitVector.size() / 8);
 	//        //m emcpy(exp.data(), bitVector.data(), bitVector.size() / 8);
-	//        copyBytes(exp, bitVector);
+	//        osuCrypto::copyBytes(exp, bitVector);
 
 	//        std::string act = literals[i];
 	//        if (act.compare(exp) != 0)

--- a/thirdparty/getLibOTe.cmake
+++ b/thirdparty/getLibOTe.cmake
@@ -2,7 +2,7 @@
 set(USER_NAME           )      
 set(TOKEN               )      
 set(GIT_REPOSITORY      "https://github.com/osu-crypto/libOTe.git")
-set(GIT_TAG             "e12bfbb459ad38908e110a9db538f2b82fb14d18")
+set(GIT_TAG             "")
 
 set(DEP_NAME            libOTe)          
 set(CLONE_DIR "${SECUREJOIN_THIRDPARTY_CLONE_DIR}/${DEP_NAME}")


### PR DESCRIPTION
This pull request does the following:

- makes changes to the cmake setup to build and install correctly to the designated install location
- updates to the newest version of libOTe and refactors function calls to `setBytes`, `copyBytes`, `copyBytesMin`, and `asSpan` to use the new `cryptoTools` versions
- obtains compatibility with GCC v13 (ships with Ubuntu 24), whereas it previously only worked with GCC v11 (ships with Ubuntu 22), although I did not test GCC v12

I'm not too experienced with cmake, so it's possible that some of my changes are bad, but this version can successfully link with my external project.

There are a lot of files changed, but most of them are just to add `osuCrypto::` before the function calls that were refactored.

There is one error when compiling with GCC v14 (used in some rolling release distros, e.g., Arch), but it is not in this library. The issue is that there is a missing `#include <algorithm>` in `cryptoTools/Circuit/MxCircuit.h` that is not an issue when compiling `cryptoTools` by itself.

Closes #3.