### PR TITLE
Fixes for Mac ARM

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -67,6 +67,6 @@ install(EXPORT secureJoinTargets
 install(DIRECTORY secure-join DESTINATION include/secureJoin)
 
 install(FILES 
-    out/build/linux/secure-join/config.h   # Install the generated config.h
+    out/build/${SECUREJOIN_CONFIG}/secure-join/config.h   # Install the generated config.h
     DESTINATION include/secureJoin/secure-join
 )

--- a/tests/LowMCPerm_Test.cpp
+++ b/tests/LowMCPerm_Test.cpp
@@ -4,7 +4,7 @@
 #include "cryptoTools/Common/TestCollection.h"
 
 using namespace secJoin;
-template<u64 n>
+template<size_t n>
 auto& bytes(const std::bitset<n>&b)
 {
 	return *(std::array<u8, sizeof(b)>*)&b;


### PR DESCRIPTION
I had to make these two small changes to get secure join to compile on my ARM mac. I also needed to build with

```
-DSECUREJOIN_ENABLE_SSE=OFF
```

to prevent SSE/AVX from being used.